### PR TITLE
Add active record model option to query

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -97,8 +97,10 @@ module Searchkick
           includes: options[:include] || options[:includes],
           json: !options[:json].nil?,
           match_suffix: @match_suffix,
-          highlighted_fields: @highlighted_fields || []
+          highlighted_fields: @highlighted_fields || [],
+          active_record_model: @active_record_model
         }
+
         Searchkick::Results.new(searchkick_klass, response, opts)
       end
     end
@@ -567,6 +569,10 @@ module Searchkick
 
         # routing
         @routing = options[:routing] if options[:routing]
+      end
+
+      if options[:active_record_model]
+        @active_record_model = options[:active_record_model]
       end
 
       @body = payload

--- a/lib/searchkick/results.rb
+++ b/lib/searchkick/results.rb
@@ -27,7 +27,7 @@ module Searchkick
           results = {}
 
           hits.group_by { |hit, _| hit["_type"] }.each do |type, grouped_hits|
-            results[type] = results_query(type.camelize.constantize, grouped_hits).to_a.index_by { |r| r.id.to_s }
+            results[type] = results_query(active_record_model(type), grouped_hits).to_a.index_by { |r| r.id.to_s }
           end
 
           # sort
@@ -168,6 +168,14 @@ module Searchkick
     end
 
     private
+
+    def active_record_model(type)
+      if options[:active_record_model].present?
+        options[:active_record_model]
+      else
+        type.camelize.constantize
+      end
+    end
 
     def results_query(records, hits)
       ids = hits.map { |hit| hit["_id"] }

--- a/test/query_test.rb
+++ b/test/query_test.rb
@@ -10,4 +10,11 @@ class QueryTest < Minitest::Test
     assert_equal ["Apple", "Milk"], query.map(&:name).sort
     assert_equal ["Apple", "Milk"], query.execute.map(&:name).sort
   end
+
+  def test_records_with_active_record_model
+    store_names ["Milk", "Apple"]
+    query = Product.search("milk", active_record_model: ProductWithDeleted, execute: false)
+
+    assert_equal ProductWithDeleted, query.execute.first.class
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -182,6 +182,9 @@ else
   class Product < ActiveRecord::Base
   end
 
+  class ProductWithDeleted < Product
+  end
+
   class Store < ActiveRecord::Base
     has_many :products
   end


### PR DESCRIPTION
This fix is for gap's soft delete implementation. This is only for active record.
